### PR TITLE
Reloading the app to fix service worker issues

### DIFF
--- a/frontend/src/registerServiceWorker.js
+++ b/frontend/src/registerServiceWorker.js
@@ -68,6 +68,8 @@ function registerValidSW(swUrl) {
               // It's the perfect time to display a "New content is
               // available; please refresh." message in your web app.
               console.log('New content is available; please refresh.');
+              // Reloading the app to avoid possible SW issues.
+              window.location.reload();
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a


### PR DESCRIPTION
I am really not comfortable with this approach since I am thinking about the possible side effects this can cause.
Like if the user is making a reservation or payment and then we refresh the app in between it is bad user experience and may cause some side effects which we have not planned for.
The other solution would be show a modal or a toast or some message somewhere on the screen.