### PR TITLE
Remove debounce from lazy loading

### DIFF
--- a/frontend/src/views/consumer/event-listing/index.js
+++ b/frontend/src/views/consumer/event-listing/index.js
@@ -78,7 +78,7 @@ export default withTheme(
             {displayableEvents.length > 0 ? (
               <ScrollContainer>
                 {displayableEvents.map(event => (
-                  <LazyLoad height={320} offsetVertical={2000}>
+                  <LazyLoad height={320} debounce={false} offsetVertical={2200}>
                     <EventCard
                       expandable
                       active={selectedEvent && selectedEvent.id === event.id}


### PR DESCRIPTION
Debounce is set to false so that when the user starts scrolling, the contents below will start loading (rather than waiting for the scrolling to stop).

**This way, we don't have to use any additional `<PlaceHolder>` before the `<LazyLoad>` until the event is called and displayed on the screen**