### PR TITLE
Update producer consumer ui

### DIFF
--- a/frontend/src/views/consumer/event-listing/EventDetail.jsx
+++ b/frontend/src/views/consumer/event-listing/EventDetail.jsx
@@ -74,11 +74,13 @@ export default class EventDetails extends Component {
             />
           ))}
         />
-        <ListItem
-          color={themeColor}
-          title="Lisätiedot ja peruutukset"
-          content={event.contactInformation}
-        />
+        {!soldOut && (
+          <ListItem
+            color={themeColor}
+            title="Lisätiedot ja peruutukset"
+            content={event.contactInformation}
+          />
+        )}
         <ListItem
           color={themeColor}
           title="Paikkoja jäljellä"
@@ -87,7 +89,10 @@ export default class EventDetails extends Component {
         {soldOut && (
           <ListItem
             color={soldOutColor}
-            title="Jos tilaisuus on loppuunmyyty, voit tiedustella peruutuspaikkoja tapahtuman tuottajalta."
+            title={
+              'Tilaisuus on loppuunmyyty. Jos haluat ilmoittautua jonoon, ole yhteydessä: ' +
+              event.contactInformation
+            }
           />
         )}
       </Wrapper>

--- a/frontend/src/views/consumer/event-listing/EventDetail.jsx
+++ b/frontend/src/views/consumer/event-listing/EventDetail.jsx
@@ -41,6 +41,7 @@ export default class EventDetails extends Component {
     const { event } = this.props;
     const soldOut = event.totalAvailableTickets < 1;
     const themeColor = soldOut ? '#9B9B9B' : event.themeColor;
+    const soldOutColor = '#FF4B4B';
     return (
       <Wrapper>
         <ListItem
@@ -75,7 +76,7 @@ export default class EventDetails extends Component {
         />
         <ListItem
           color={themeColor}
-          title="Lisätietoja"
+          title="Lisätiedot ja peruutukset"
           content={event.contactInformation}
         />
         <ListItem
@@ -83,6 +84,12 @@ export default class EventDetails extends Component {
           title="Paikkoja jäljellä"
           content={event.totalAvailableTickets + ' jäljellä'}
         />
+        {soldOut && (
+          <ListItem
+            color={soldOutColor}
+            title="Jos tilaisuus on loppuunmyyty, voit tiedustella peruutuspaikkoja tapahtuman tuottajalta."
+          />
+        )}
       </Wrapper>
     );
   }

--- a/frontend/src/views/producer/dashboard/edition-form/Editor.jsx
+++ b/frontend/src/views/producer/dashboard/edition-form/Editor.jsx
@@ -272,7 +272,7 @@ class Editor extends React.Component {
           <Row fullsize>
             <InputField
               backgroundColor={inputBackgroundColor}
-              label="Lisätiedot"
+              label="Lisätiedot ja peruutukset"
               lightMode
               type="text"
               value={this.internalData.eventDraft.contactInformation}


### PR DESCRIPTION
#### When tickets run out, the producer details are not shown directly under "Lisätiedot ja peruutukset". Instead a text in red color is shown for users to contact producer to be added to the queue.

`When tickets run out:`
![image](https://user-images.githubusercontent.com/37651584/58800972-ef5e2000-8611-11e9-9dab-fec5fb2df0c3.png)

`When tickets are available:`
![image](https://user-images.githubusercontent.com/37651584/58801007-08ff6780-8612-11e9-9bc4-c566825de7e7.png)
