### PR TITLE
Remove text on top of main logo

### DIFF
--- a/frontend/src/components/logo/index.js
+++ b/frontend/src/components/logo/index.js
@@ -28,19 +28,6 @@ const SvgComponent = props => (
                 fill="#86cbf6"
               />
             </g>
-            {props.noText || (
-              <text
-                transform="translate(20 69.15)"
-                fontSize={20}
-                fontFamily="GT-Walsheim"
-                fontWeight={500}
-                letterSpacing="-.01em"
-                id="Vantaa"
-                fill="white"
-              >
-                <tspan className="cls-6">Vantaa</tspan>
-              </text>
-            )}
           </g>
         </g>
       </g>

--- a/frontend/src/views/consumer/app-bar/index.js
+++ b/frontend/src/views/consumer/app-bar/index.js
@@ -60,7 +60,6 @@ const LeftBox = styled.div`
 
 const LogoBox = props => (
   <LeftBox>
-    <Logo noText={false} />
     <div>
       <Typography type="subheader">Vantaa</Typography>
       <Typography type="subheader">Kulttuuria</Typography>

--- a/frontend/src/views/producer/dashboard/Appbar.jsx
+++ b/frontend/src/views/producer/dashboard/Appbar.jsx
@@ -45,7 +45,6 @@ class Appbar extends React.Component {
       <React.Fragment>
         <Wrapper>
           <LogoSection>
-            <Logo noText={false} />
             <Typography type="headline" color="white">
               VANTAA
             </Typography>


### PR DESCRIPTION
### Remove the text "Vantaa" written on top of the main logo

**Removed the text on loading screen main logo and also removed the main logo on consumer-homepage**

![232323](https://user-images.githubusercontent.com/37651584/59034151-17988980-8873-11e9-8fa8-98fba83292d0.png)

**Removed the main logo in producer-homepage**

![image](https://user-images.githubusercontent.com/37651584/59034414-ac02ec00-8873-11e9-8f3e-ff74d81d8451.png)

