### PR TITLE
fix: require at least 1 ticket when booking tickets

### DIFF
--- a/frontend/src/views/consumer/event-listing/EventBooking.jsx
+++ b/frontend/src/views/consumer/event-listing/EventBooking.jsx
@@ -165,16 +165,17 @@ export default connect('store')(
       const formDisabled = event.totalAvailableTickets < 1;
       const themeColor = formDisabled ? '#9B9B9B' : event.themeColor;
       const { totalCost, totalTicket } = this.getPricingAggrevate();
-      const submittable =
-        (isGroupConductorCustomer
-          ? internalState.school &&
-          internalState.classRoom &&
-          internalState.name &&
-          isValidNumber(internalState.phoneNumber, 'FI') &&
-          internalState.privacy
-          : internalState.name &&
-          isValidNumber(internalState.phoneNumber, 'FI')) &&
-        internalState.privacy; // can't have an empty order
+
+      const isCommonInputValid = internalState.name &&
+        isValidNumber(internalState.phoneNumber, 'FI') &&
+        internalState.privacy;
+
+      const isGroupConductorInputValid = isGroupConductorCustomer
+        ? internalState.school && internalState.classRoom
+        : true;
+
+      const submittable = totalTicket > 0 && isCommonInputValid && isGroupConductorInputValid;
+
       return (
         <Wrapper bgColor={themeColor}>
           <TitleBox>


### PR DESCRIPTION
Previously it was possible to make reservations with zero tickets.
Buying tickets wasn't affected, because the button is disabled when the
total price is zero. Now the reservation button is disabled when the
total amount of tickets is zero.

The `submittable` boolean was additionally refactored to improve
readability and decrease redundancy. The logic itself stays unchanged.

I thought about adding some validation to the backend as well instead of
relying just on frontend validation. Adding the Min(1) validator to the
TicketsDTO won't work, since one could make a reservation for an event
having multiple ticket categories, and all categories, including the
ones with zero tickets, are always sent to the backend. It might be
possible to validate the reservation dto itself to make sure that at
least one ticket is actually present. This would of course require us to
send a specific error code to the frontend and handle it separately from
the current logic. All in all, this seems to be a quite a bit of extra
work for a quick fix such as this one, and it's highly unlikely that the
API would be accessed directly to make reservations.